### PR TITLE
Rewrote plugin to allow for symbols to update themselves.

### DIFF
--- a/ImportSymbols.sketchplugin/Contents/Sketch/importSymbols.js
+++ b/ImportSymbols.sketchplugin/Contents/Sketch/importSymbols.js
@@ -1,52 +1,270 @@
-var importSymbols = function (context) {
-	var doc = context.document;
-	var docData = doc.documentData();
-	var selection = context.selection;
-	var allPages = context.document.pages();
-	var openDialog = NSOpenPanel.openPanel();
-	openDialog.setCanChooseFiles(true);
-	openDialog.setAllowedFileTypes(["sketch"]);
-	openDialog.setCanChooseDirectories(false);
-	openDialog.setAllowsMultipleSelection(false);
-	openDialog.setCanCreateDirectories(false);
-	openDialog.setTitle("Select a Sketch document to import Symbols from");
+const FILE_TYPE = 'com.bohemiancoding.sketch.drawing';
+const FILE_EXTENSIONS = ['sketch'];
+const FILE_SELECTION_TEXT = 'Select a Sketch document to import symbols from.';
+const FILE_SELECTION_ERROR = 'Could not open file. Is it a Sketch file?';
+var command;
 
-	if( openDialog.runModal() == NSOKButton ) {
-		var sourceDoc = MSDocument.new();
-		
-		if(sourceDoc.readFromURL_ofType_error(openDialog.URL(), "com.bohemiancoding.sketch.drawing", nil)) {
-			// Get source document symbols
-			var sourceSymbols = sourceDoc.documentData().allSymbols();
-			var addCount = 0;
-			log('Selected Sketch doc contains '+ sourceSymbols.count() + " symbols...");
+/**
+ * Open a file prompt.
+ * @return {NSOpenPanel}
+ */
+function openPrompt() {
+	var panel = NSOpenPanel.openPanel();
+	panel.setCanChooseFiles(true);
+	panel.setAllowedFileTypes(FILE_EXTENSIONS);
+	panel.setCanChooseDirectories(false);
+	panel.setAllowsMultipleSelection(false);
+	panel.setCanCreateDirectories(false);
+	panel.setTitle(FILE_SELECTION_TEXT);
+	return panel;
+}
 
-			for(var i = 0;i<sourceSymbols.count();i++) {
-				var symbol = sourceSymbols.objectAtIndex(i);
-				var clonedSymbol = symbol.copy();
-				var rect = clonedSymbol.rect();
-				var targetSymbols = doc.documentData().allSymbols();
+/**
+ * Attempt to open a file if it is of the proper type.
+ * @param {String} url
+ * @return {MSDocument|nil}
+ */
+function tryToOpenFile(url) {
+	var doc = MSDocument.new();
+	if (doc.readFromURL_ofType_error(url, FILE_TYPE, nil)) return doc;
+	return nil;
+}
 
-				if(targetSymbols.length > 0){
-					var lastTargetSymbol = targetSymbols[targetSymbols.count()-1];
-					var lastTargetSymbolRect = lastTargetSymbol.rect();
-					rect.origin.x = 0;
-					rect.origin.y = lastTargetSymbolRect.origin.y + lastTargetSymbolRect.size.height + 50;
-					clonedSymbol.rect = rect;
-				}else{
-					rect.origin.x = 0;
-					rect.origin.y = rect.origin.y + rect.size.height + 50;
-					clonedSymbol.rect = rect;
-				}
-				// If Symbols page exists, switch to it, otherwise create it then switch to it.
-				doc.setCurrentPage(docData.symbolsPageOrCreateIfNecessary());
-				var currentPage = context.document.currentPage();
-				// Add Symbol to current/target doc
-				currentPage.addLayers([clonedSymbol]);
-				addCount++;
-			}
-			doc.showMessage(addCount+" Symbols were imported successfully. Nice One!");	
+/**
+ * Attempt to close a file if one is passed.
+ * @param {MSDocument|nil} doc
+ */
+function tryToCloseFile(doc) {
+	if (!doc) return;
+	doc.close();
+	doc = nil;
+}
+
+/**
+ * Get all the symbols for a document.
+ * @param {MSDocument} doc
+ * @return {NSArray}
+ */
+function getSymbols(doc) {
+	return doc.documentData().allSymbols()
+}
+
+/**
+ * Get the last symbol in an array.
+ * @param {NSArray} symbols
+ * @return {MSSymbolMaster|nil}
+ */
+function getLastSymbol(symbols) {
+	var len = symbols.count();
+	return len > 0 ? symbols[len - 1] : nil;
+}
+
+/**
+ * Find a symbol by name.
+ * @param {NSArray} symbols
+ * @param {String} id
+ * @return {MSSymbolMaster|nil}
+ */
+function findSymbol(symbols, id) {
+
+	var i = 0;
+	var len = symbols.count();
+	var importId;
+
+	for(; i < len; i++) {
+		importId = getLayerValue(symbols.objectAtIndex(i), 'import_id');
+		if (importId && importId.isEqualToString(id)) {
+			return symbols.objectAtIndex(i);
 		}
-		sourceDoc.close();
-		sourceDoc = nil;
 	}
+
+	return nil;
+}
+
+/**
+ * Add a list of symbols to a document.
+ * @param {MSDocument} doc
+ * @param {NSArray} sourceSymbols
+ */
+function addSymbols(doc, sourceSymbols) {
+
+	var symbols = getSymbols(doc);
+	var lastSymbol = getLastSymbol(symbols);
+
+	var i = 0;
+	var len = sourceSymbols.count();
+	var addCount = 0;
+	var updateCount = 0;
+	var ret;
+
+	showSymbolsPage(doc);
+
+	for(; i < len; i++) {
+		ret = addSymbol(doc, symbols, sourceSymbols.objectAtIndex(i), lastSymbol);
+		(ret.type === 'add' ? addCount++ : updateCount++);
+		lastSymbol = ret.symbol;
+	}
+
+	doc.showMessage(addCount + ' symbols added, ' + updateCount + ' updated.');
+}
+
+/**
+ * Add a symbol to a document. If a symbol with that name already exists, replace it
+ * and all the references to it. If it does not, place after the last symbol.
+ * @param {MSDocument} doc
+ * @param {NSArray} docSymbols
+ * @param {MSSymbolMaster} symbol
+ * @param {MSSymbolMaster|nil} lastSymbol
+ * @return {Object}
+ */
+function addSymbol(doc, docSymbols, symbol, lastSymbol) {
+
+	var symbolID = symbol.symbolID();
+	var clonedSymbol = cloneSymbolAndPositionRelatively(symbol, lastSymbol);
+	var existingSymbol = findSymbol(docSymbols, symbolID);
+	setLayerValue(clonedSymbol, 'import_id', symbolID);
+
+	return {
+		type: existingSymbol ? 'update' : 'add',
+		symbol: existingSymbol ? replaceSymbol(doc, existingSymbol, clonedSymbol) : insertSymbol(doc, clonedSymbol)
+	};
+}
+
+/**
+ * Clone a symbol and position it relative to another.
+ * @param {MSSymbolMaster} symbol
+ * @param {MSSymbolMaster} sibling
+ * @return {MSSymbolMaster}
+ */
+function cloneSymbolAndPositionRelatively(symbol, sibling) {
+	var clone = symbol.copy();
+	var bRect = sibling && sibling.rect();
+	var rect = clone.rect();
+	var y = bRect ? bRect.origin.y + bRect.size.height + 50 : 0;
+	rect.origin.x = 0;
+	rect.origin.y = y;
+	clone.rect = rect;
+	return clone;
+}
+
+/**
+ * If Symbols page exists, switch to it, otherwise create it then switch to it.
+ * @param {MSDocument} doc
+ */
+function showSymbolsPage(doc) {
+	doc.setCurrentPage(doc.documentData().symbolsPageOrCreateIfNecessary());
+}
+
+/**
+ * Replace one symbol with another.
+ * @param {MSDocument} doc
+ * @param {MSSymbolMaster} oldSymbol
+ * @param {MSSymbolMaster} newSymbol
+ * @return {MSSymbolMaster}
+ */
+function replaceSymbol(doc, oldSymbol, newSymbol) {
+	insertSymbolAtPosition(doc, newSymbol, getSymbolPosition(oldSymbol));
+	updateSymbolInstances(oldSymbol, newSymbol);
+	removeSymbol(oldSymbol);
+	return newSymbol;
+}
+
+/**
+ * Update instances of a symbol to use another as their master.
+ * @param {MSSymbolMaster} oldSymbol
+ * @param {MSSymbolMaster} newSymbol
+ */
+function updateSymbolInstances(oldSymbol, newSymbol) {
+	var instances = oldSymbol.allInstances();
+	var i = 0;
+	var len = instances.count();
+	for (; i < len; i++) {
+		instances.objectAtIndex(i).changeInstanceToSymbol(newSymbol);
+	}
+}
+
+/**
+ * Insert a symbol at a given set of coordinates
+ * @param {MSSymbolMaster} symbol
+ * @param {Object} position
+ */
+function insertSymbolAtPosition(doc, symbol, position) {
+	var rect = symbol.rect();
+	rect.origin.x = position.x;
+	rect.origin.y = position.y;
+	symbol.rect = rect;
+	insertSymbol(doc, symbol);
+}
+
+/**
+ * Get the coordinates of a symbol.
+ * @param {MSSymbolMaster} symbol
+ * @return {Object}
+ */
+function getSymbolPosition(symbol) {
+	var rect = symbol.rect();
+	return {
+		x: rect.origin.x,
+		y: rect.origin.y
+	};
+}
+
+/**
+ * Remove a symbol from the document.
+ * @param {MSSymbolMaster} symbol
+ */
+function removeSymbol(symbol) {
+	symbol.removeFromParent();
+	symbol = nil;
+}
+
+/**
+ * Insert a symbol into the document.
+ * @param {MSDocument} doc
+ * @param {MSSymbolMaster} symbol
+ * @return {MSSymbolMaster}
+ */
+function insertSymbol(doc, symbol) {
+	doc.currentPage().addLayers([symbol]);
+	return symbol;
+}
+
+/**
+ * Store an arbitrary value on a layer.
+ * @param {Mixed} layer
+ * @param {String} name
+ * @param {String} val
+ */
+function setLayerValue(layer, name, val) {
+	return command.setValue_forKey_onLayer(val, name, layer);
+}
+
+/**
+ * Get an arbitrary value from a layer.
+ * @param  {Mixed} layer
+ * @param  {String} name
+ * @return {String}
+ */
+function getLayerValue(layer, name) {
+	return command.valueForKey_onLayer(name, layer);
+}
+
+/**
+ * Exported function run when plugin is called.
+ * @param {Object} context
+ */
+function importSymbols(context) {
+
+	// Prompt for a file
+	var panel = openPrompt();
+	if (panel.runModal() !== NSOKButton) return;
+	var fileURL = panel.URL();
+
+	command = context.command;
+
+	// Try to open the file, get its symbols, add them to the current document, then close the file.
+	var doc;
+	if (doc = tryToOpenFile(fileURL)) addSymbols(context.document, getSymbols(doc));
+	else context.document.showMessage(FILE_SELECTION_ERROR);
+	tryToCloseFile(doc);
 }

--- a/ImportSymbols.sketchplugin/Contents/Sketch/importSymbols.js
+++ b/ImportSymbols.sketchplugin/Contents/Sketch/importSymbols.js
@@ -50,13 +50,17 @@ function getSymbols(doc) {
 }
 
 /**
- * Get the last symbol in an array.
+ * Get the last symbol on the page (bottom-most, right-most).
  * @param {NSArray} symbols
  * @return {MSSymbolMaster|nil}
  */
-function getLastSymbol(symbols) {
-	var len = symbols.count();
-	return len > 0 ? symbols[len - 1] : nil;
+function getBottomSymbol(symbols) {
+	return symbols.slice().sort(function(a, b) {
+		var aRect = a.rect().origin;
+		var bRect = b.rect().origin;
+		// A is above B, -1. A and B are horizontally equal, A is left of B, -1; B is left of A, 1; A and B are overlapping, 0. B is above A, 1.
+		return aRect.y < bRect.y ? -1 : (aRect.x < bRect.x ? -1 : (aRect.x === bRect.x ? 0 : 1));
+	}).pop();
 }
 
 /**
@@ -112,7 +116,7 @@ function findSymbolByName(symbols, name) {
 function addSymbols(doc, sourceSymbols, replaceBy) {
 
 	var symbols = getSymbols(doc);
-	var lastSymbol = getLastSymbol(symbols);
+	var lastSymbol = getBottomSymbol(symbols);
 
 	var i = 0;
 	var len = sourceSymbols.count();
@@ -237,7 +241,6 @@ function replaceSymbol(doc, oldSymbol, newSymbol) {
  */
 function updateSymbolInstances(oldSymbol, newSymbol) {
 	var instances = oldSymbol.allInstances();
-	log(oldSymbol);
 	var i = 0;
 	var len = instances.count();
 	for (; i < len; i++) {

--- a/ImportSymbols.sketchplugin/Contents/Sketch/manifest.json
+++ b/ImportSymbols.sketchplugin/Contents/Sketch/manifest.json
@@ -8,18 +8,24 @@
   "updateURL": "https://github.com/kmerc/sketch-import-symbols",
   "compatibleVersion": 1,
   "bundleVersion": 1,
-  "commands": [
-    {
-      "name": "Import Symbols",
-      "identifier": "all",
+  "commands": [{
+      "name": "Import By ID",
+      "identifier": "id",
       "shortcut": "ctrl shift i",
       "script": "importSymbols.js",
-      "handler": "importSymbols"
+      "handler": "importSymbolsByID"
+    }, {
+      "name": "Import By Name",
+      "identifier": "name",
+      "shortcut": "ctrl alt shift i",
+      "script": "importSymbols.js",
+      "handler": "importSymbolsByName"
     }
   ],
   "menu": {
     "items": [
-      "all"
+      "id",
+      "name"
     ]
   }
 }

--- a/ImportSymbols.sketchplugin/Contents/Sketch/manifest.json
+++ b/ImportSymbols.sketchplugin/Contents/Sketch/manifest.json
@@ -3,7 +3,7 @@
   "description": "Plugin to import symbols from another Sketch file.",
   "author": "Caleb Mercer",
   "homepage": "https://github.com/kmerc/sketch-import-symbols",
-  "version": 4.1,
+  "version": 5.0,
   "identifier": "com.kmerc.sketch.import-plugin",
   "updateURL": "https://github.com/kmerc/sketch-import-symbols",
   "compatibleVersion": 1,


### PR DESCRIPTION
Sorry for the huge delta, but I had to make some major changes to get this set up to work. I saw your discussion [here (#9)](https://github.com/kmerc/sketch-import-symbols/issues/9) yesterday when I ran into this problem myself.

In this PR, when symbols are imported they store the objectID of the original symbol. This lets us replace those symbols when the same file is imported again. Symbol overrides continue to work!

Also fixed a bug with the canvas size of the imported symbols being incorrect.

Totally understand if you're not comfortable with such a huge change in the code. I'm happy to keep this as a fork but thought I would offer it up as a solution.

Paging @florianpnn as well, since you had the original issue.